### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Game Code Options:
 * DRX - DragonRealms Platinum
 * DRF - DragonRealms Fallen
 
-example usage with CRON:
+example usage with CRON (Times in UTC):
 
 ```yaml
 #.github/workflows/rewards.yml
 name: rewards
 on:
+  workflow_dispatch:
   schedule:
     - cron: "5 1 * * *"
 jobs:

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     name: login account
     steps:
-      - uses: ondreian/simu-rewards@v1
+      - uses: ondreian/simu-rewards@v1.1.0
         with:
           account: ${{ secrets.ACCOUNT1 }}
           password: ${{ secrets.PASSWORD1 }}
-      - uses: ondreian/simu-rewards@v1
+      - uses: ondreian/simu-rewards@v1.1.0
         with:
           account: ${{ secrets.ACCOUNT2 }}
           password: ${{ secrets.PASSWORD2 }}


### PR DESCRIPTION
Expand readme to indicate CRON job is in UTC. Also added `workflow_dispatch` to the default rewards.yml to allow for job to be manually run if someone wants to test the workflow.