### PR TITLE
docs: remove reference to timeout usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ jobs:
   login-account:
     runs-on: ubuntu-latest
     name: login account
-    timeout-minutes: 5
     steps:
       - uses: ondreian/simu-rewards@v1
         with:
@@ -74,7 +73,6 @@ jobs:
   login-account:
     runs-on: ubuntu-latest
     name: login account
-    timeout-minutes: 5
     steps:
       - uses: ondreian/simu-rewards@v1
         with:


### PR DESCRIPTION
with the update to the base action, no longer need end-users to have timeout in their repository github action.