### PR TITLE
docs(readme): repoint examples to use v1 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     name: login account
     steps:
-      - uses: ondreian/simu-rewards@v1.2.0
+      - uses: ondreian/simu-rewards@v1
         with:
           account: ${{ secrets.ACCOUNT1 }}
           password: ${{ secrets.PASSWORD1 }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     name: login account
     steps:
-      - uses: ondreian/simu-rewards@v1.2.0
+      - uses: ondreian/simu-rewards@v1
         with:
           account: ${{ secrets.ACCOUNT1 }}
           password: ${{ secrets.PASSWORD1 }}


### PR DESCRIPTION
v1 tag is now resolved for auto-releases, so safe to use again. Updated documentation examples to utilize that tag instead.